### PR TITLE
Bugfix/is mobile with touch on safari mobile

### DIFF
--- a/src/Experience/Camera.js
+++ b/src/Experience/Camera.js
@@ -96,6 +96,7 @@ export default class Camera {
 
     function conditionsToMoveCamera(target, btnMusic, btnCredits) {
       alert(isMobileWithTouch());
+      alert(target.closest(".btn-next"));
       if (isMobileWithTouch()) {
         if (target.closest(".btn-next")) {
           return true;

--- a/src/Experience/Camera.js
+++ b/src/Experience/Camera.js
@@ -95,10 +95,6 @@ export default class Camera {
     }
 
     function conditionsToMoveCamera(target, btnMusic, btnCredits) {
-      // alert(isMobileWithTouch());
-      alert(target.matches(".btn-next-text"));
-      // console.log(target.closest(".btn-next-text"));
-      // console.log(target.matches(".btn-next-text"));
       if (isMobileWithTouch()) {
         if (target.matches(".btn-next-text")) {
           return true;

--- a/src/Experience/Camera.js
+++ b/src/Experience/Camera.js
@@ -18,8 +18,6 @@ export default class Camera {
     this.btnMusic = document.querySelector(".btn-music");
     this.btnCredits = document.querySelector(".btn-credits");
 
-    this.isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-
     this.setInstance();
     this.setOrbitControls();
   }
@@ -48,12 +46,7 @@ export default class Camera {
 
     window.addEventListener("mouseup", (event) => {
       if (
-        conditionsToMoveCamera(
-          event.target,
-          this.btnMusic,
-          this.btnCredits,
-          this.isMobile
-        )
+        conditionsToMoveCamera(event.target, this.btnMusic, this.btnCredits)
       ) {
         switch (position) {
           case 0:
@@ -101,8 +94,9 @@ export default class Camera {
       return false;
     }
 
-    function conditionsToMoveCamera(target, btnMusic, btnCredits, isMobile) {
-      if (isMobile === true) {
+    function conditionsToMoveCamera(target, btnMusic, btnCredits) {
+      alert(isMobileWithTouch());
+      if (isMobileWithTouch()) {
         if (target.closest(".btn-next")) {
           return true;
         }
@@ -116,6 +110,28 @@ export default class Camera {
         }
         return false;
       }
+    }
+
+    function isMobileWithTouch() {
+      // Check for touch event support
+      if (
+        "ontouchstart" in window ||
+        navigator.maxTouchPoints > 0 ||
+        navigator.msMaxTouchPoints > 0
+      ) {
+        return true;
+      }
+
+      // Check for the presence of certain keywords in the user agent
+      const userAgent = window.navigator.userAgent;
+      const keywords = ["Mobile", "Android", "iPhone", "iPad"];
+      for (const keyword of keywords) {
+        if (userAgent.indexOf(keyword) !== -1) {
+          return true;
+        }
+      }
+
+      return false;
     }
 
     // Debug

--- a/src/Experience/Camera.js
+++ b/src/Experience/Camera.js
@@ -96,7 +96,7 @@ export default class Camera {
 
     function conditionsToMoveCamera(target, btnMusic, btnCredits) {
       // alert(isMobileWithTouch());
-      // alert(target.matches(".btn-next-text"));
+      alert(target.matches(".btn-next-text"));
       // console.log(target.closest(".btn-next-text"));
       // console.log(target.matches(".btn-next-text"));
       if (isMobileWithTouch()) {

--- a/src/Experience/Camera.js
+++ b/src/Experience/Camera.js
@@ -44,7 +44,7 @@ export default class Camera {
   setOrbitControls() {
     let position = 0;
 
-    window.addEventListener("mouseup", (event) => {
+    window.addEventListener("click", (event) => {
       if (
         conditionsToMoveCamera(event.target, this.btnMusic, this.btnCredits)
       ) {
@@ -85,9 +85,9 @@ export default class Camera {
 
     function isInsideBtns(target) {
       if (
-        target.closest(".stop") ||
-        target.closest(".play") ||
-        target.closest(".credits-title")
+        target.matches(".stop") ||
+        target.matches(".play") ||
+        target.matches(".credits-title")
       ) {
         return true;
       }
@@ -95,10 +95,12 @@ export default class Camera {
     }
 
     function conditionsToMoveCamera(target, btnMusic, btnCredits) {
-      alert(isMobileWithTouch());
-      alert(target.closest(".btn-next"));
+      // alert(isMobileWithTouch());
+      // alert(target.matches(".btn-next-text"));
+      // console.log(target.closest(".btn-next-text"));
+      // console.log(target.matches(".btn-next-text"));
       if (isMobileWithTouch()) {
-        if (target.closest(".btn-next")) {
+        if (target.matches(".btn-next-text")) {
           return true;
         }
         return false;

--- a/src/index.html
+++ b/src/index.html
@@ -93,10 +93,10 @@
     <div class="cursor small">
       <p>continuar</p>
     </div>
-    <div class="btn-next">
-      <p class="btn-next-text">continuar</p>
-    </div>
-    <div class="btn-music hoverable">
+    <button class="btn-next">
+      <span class="btn-next-text">continuar</span>
+    </button>
+    <button class="btn-music hoverable">
       <img
         class="play"
         src="./images/music/play-sound.png"
@@ -111,10 +111,10 @@
         width="210"
         height="162"
       />
-    </div>
-    <div class="btn-credits hoverable">
-      <p class="credits-title"><a href="/credits/">créditos</a></p>
-    </div>
+    </button>
+    <button class="btn-credits hoverable">
+      <span class="credits-title"><a href="/credits/">créditos</a></span>
+    </button>
     <div class="loading-bar"></div>
     <video
       id="video1"

--- a/src/index.html
+++ b/src/index.html
@@ -94,7 +94,7 @@
       <p>continuar</p>
     </div>
     <div class="btn-next">
-      <p>continuar</p>
+      <p class="btn-next-text">continuar</p>
     </div>
     <div class="btn-music hoverable">
       <img

--- a/src/style.css
+++ b/src/style.css
@@ -89,6 +89,14 @@ body {
   transition: 0.3s;
 }
 
+/*override default button styles*/
+button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  outline: none;
+}
+
 .btn-next {
   display: none;
   animation: move 6s ease infinite;
@@ -105,9 +113,10 @@ body {
   color: #feb0ff;
   font-size: 14px;
   opacity: 0.9;
+  cursor: pointer;
 }
 
-.btn-next p {
+.btn-next span {
   position: fixed;
   top: 0;
   right: -85%;
@@ -173,7 +182,7 @@ body {
   animation: move 6s ease infinite;
 }
 
-.btn-credits p {
+.btn-credits span {
   position: fixed;
   top: 4px;
   right: -80%;

--- a/src/style.css
+++ b/src/style.css
@@ -111,6 +111,7 @@ body {
   position: fixed;
   top: 0;
   right: -85%;
+  cursor: pointer;
 }
 
 @keyframes move {


### PR DESCRIPTION
# Description

- Fix click event not firing in Safari Mobile. Sadly I do not have an Iphone phone right now to test the case properly, but I had help of a friend and seems fixed based on bugs described here:
https://www.shdon.com/blog/2013/06/07/why-your-click-events-don-t-work-on-mobile-safari 
- isMobileWithTouch() added to improve detection.
- Div elements replaced by buttons has more semantic sense.
- `cursor: pointer` added to buttons
- `mouseup` replaced by `click` event
- `target.closest` replaced by `target.matches`

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update